### PR TITLE
docs: Update README.md include submodule init

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ For macOS, the included `scripts/build/build_from_source.sh` builds the Metal ba
 # 1. Clone upstream
 git clone https://github.com/leejet/stable-diffusion.cpp.git
 cd stable-diffusion.cpp
+git submodule update --recursive --init
 mkdir build && cd build
 
 # 2. Configure for your backend (pick ONE)


### PR DESCRIPTION
The instructions missed the submodule init, likely resulting in a bunch of people unable to follow instructions unless they are familiar with building C projects.

Small fix

Original error:

```
CMake Error at CMakeLists.txt:328 (add_subdirectory):
  The source directory

    /Users/lewiscowles/Projects/study/stable-diffusion.cpp/ggml

  does not contain a CMakeLists.txt file.
```

I deleted ggml 😊  and then saw

```
CMake Error at CMakeLists.txt:328 (add_subdirectory):
  add_subdirectory given source "ggml" which is not an existing directory.
```
